### PR TITLE
Airflow init + vagrant setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 
 /Airflow/logs/*
 /Airflow/dags/__pycache__
+vagrant-setup/.vagrant

--- a/README.md
+++ b/README.md
@@ -12,17 +12,24 @@ On every Friday 15:30 US/Eastern time, an airflow DAG will pull the data in loca
 1. git clone this repo
 2. make a copy of .env_sample.txt and rename it to .env
 3. run the following shell code and place the value in .env (to avoid Linux permission error)
-````
+
+```sh
 echo -e "AIRFLOW_UID=$(id -u)" 
-````
-4. build and run docker containers
-````
+```
+
+4. initialize aifrlow
+```sh
+docker compose up --build airflow-init
+```
+
+5. build and run docker containers
+```sh
 docker compose up --build -d 
-````
-5. to remove everything (done testing)
-````
+```
+6. to remove everything (done testing)
+```sh
 docker compose down
-````
+```
 
 
 # Considerations

--- a/README.md
+++ b/README.md
@@ -17,18 +17,19 @@ On every Friday 15:30 US/Eastern time, an airflow DAG will pull the data in loca
 echo -e "AIRFLOW_UID=$(id -u)" 
 ```
 
-4. initialize aifrlow
+4. Build & initialize aifrlow
 ```sh
-docker compose up --build airflow-init
+docker compose build airflow-init
+docker compose build
 ```
 
-5. build and run docker containers
+5. Start the project services
 ```sh
-docker compose up --build -d 
+docker compose up -d
 ```
-6. to remove everything (done testing)
+6. to remove everything, including data (done testing)
 ```sh
-docker compose down
+docker compose down --volumes --remove-orphans
 ```
 
 

--- a/vagrant-setup/README.md
+++ b/vagrant-setup/README.md
@@ -39,7 +39,7 @@ Your command prompt should be showing `vagrant@ubuntu:~$`. You are now on the vi
 ### Use
 
 - follow the rest of the tutorial from the main readme in this repo.
-- when `docker compose` is up, you can access airflow from your laptop's btowser, just visit http://localhost:8080. The port is forwarded from the virtual machine to your machine.
+- when `docker compose` is up, you can access airflow UI from your laptop's btowser, just visit http://192.168.56.0:8080. The port is forwarded from the virtual machine to your machine, but it's kept isolated in a private network so that it can be accessed only from your laptop, but not by somebody sitting next to you in a cafe.
 
 ### Tidying
 

--- a/vagrant-setup/README.md
+++ b/vagrant-setup/README.md
@@ -1,0 +1,48 @@
+# Vagrant-based setup
+
+Virtual machine setup for the Airflow overview talk at DSEC given by Reinis Bekeris on 28th Seprwmvwe 2024
+
+> **DONT USE IN PRODUCTION** This is for training, demo, etc. Learn how to secure it before you use it for anything other than that.
+
+> Make sure your computer has 8G memory or more.
+
+This relates to 
+- [Reinis' DSEC talk](https://www.meetup.com/data-science-and-engineering-club/events/303120347/?eventOrigin=group_past_events)
+- [dockerized airflow setup repo](https://github.com/rbekeris/Docker_Airflow_Postgres.git)
+
+Gets you the airflow up & running and is imho the easiest way to do it.
+
+1. Install virtualbox
+
+> Use [7.0.*](https://www.virtualbox.org/wiki/Download_Old_Builds_7_0) version, the latest (7.1.*) are not supported by vagrant yet.
+
+2. Install [vagrant](https://developer.hashicorp.com/vagrant/install?product_intent=vagrant#windows)
+
+3. Clone this repo
+
+4. Using terminal/cmd/powershell in the repo folder, do
+
+The below commands will install the virtual machine and install docker inside it.
+
+```sh
+cd vagrant-setup
+vagrant up
+vagrant provision
+vagrant ssh
+```
+
+> If `vagrant up` errors out complaining about CPU, you need to configure BIOS and enable virtualization in the CPU section.
+
+
+Your command prompt should be showing `vagrant@ubuntu:~$`. You are now on the virtual machine.
+
+### Use
+
+- follow the rest of the tutorial from the main readme in this repo.
+- when `docker compose` is up, you can access airflow from your laptop's btowser, just visit http://localhost:8080. The port is forwarded from the virtual machine to your machine.
+
+### Tidying
+
+- to exit the virtual machine hit `ctr+d`
+- to stop the virtual machine run `vagrant halt` from outside of it (your system cmd/powershell/terminal)
+- to destroy the vm run `vagrant destroy` from outside of it (your system cmd/powershell/terminal)

--- a/vagrant-setup/Vagrantfile
+++ b/vagrant-setup/Vagrantfile
@@ -1,0 +1,15 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "ubuntu/jammy64"
+  config.vm.network "private_network", ip: "192.168.56.0"
+  config.vm.network "forwarded_port", guest: 8080, host: 8080, host_ip: "127.0.0.1"
+  config.vm.hostname = "ubuntu"
+  config.vm.synced_folder "../../Docker_Airflow_Postgres", "/home/vagrant/Docker_Airflow_Postgres"
+  config.vm.synced_folder ".", "/vagrant", disabled: true
+  config.vm.provision "shell", path: "bootstrap-root.sh"
+  config.vm.provider "virtualbox" do |vb|
+    vb.memory = "4352"
+  end
+end

--- a/vagrant-setup/Vagrantfile
+++ b/vagrant-setup/Vagrantfile
@@ -4,7 +4,7 @@
 Vagrant.configure("2") do |config|
   config.vm.box = "ubuntu/jammy64"
   config.vm.network "private_network", ip: "192.168.56.0"
-  config.vm.network "forwarded_port", guest: 8080, host: 8080, host_ip: "127.0.0.1"
+  config.vm.network "forwarded_port", guest: 8080, host: 8080, host_ip: "192.168.56.0"
   config.vm.hostname = "ubuntu"
   config.vm.synced_folder "../../Docker_Airflow_Postgres", "/home/vagrant/Docker_Airflow_Postgres"
   config.vm.synced_folder ".", "/vagrant", disabled: true

--- a/vagrant-setup/bootstrap-root.sh
+++ b/vagrant-setup/bootstrap-root.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+apt-get update
+apt-get install -y ca-certificates curl
+install -y -m 0755 -d /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+chmod a+r /etc/apt/keyrings/docker.asc
+echo \
+  "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+  $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+ tee /etc/apt/sources.list.d/docker.list > /dev/null
+apt-get update
+apt-get install -y \
+  docker-ce \
+  docker-ce-cli \
+  containerd.io \
+  docker-buildx-plugin \
+  docker-compose-plugin
+usermod -aG docker vagrant


### PR DESCRIPTION
In the main README I needed to add the airflow_init instruction before building the rest. With the instructions that were there, I was getting errors with the scheduler crushing. I think the scheduler DB wasn't seeded.

Separated the build from the start, in case anybody wanted to come-back few times, they don't have to build every time. Plus 

Finally, added the vagrant-based setup. This allows to build the solution in isolated space, regardless if you use windows, mac or linux. It also makes the machine setup easier (you don't have to install docker & configure the permissions)